### PR TITLE
Fix protected Go types like resource.Quantity.

### DIFF
--- a/pkg/obj_diff/change_set_test.go
+++ b/pkg/obj_diff/change_set_test.go
@@ -6,6 +6,7 @@ package obj_diff
 
 import (
 	"fmt"
+	"k8s.io/apimachinery/pkg/api/resource"
 	"testing"
 )
 
@@ -28,6 +29,7 @@ type Obj struct {
 	NestedPtr2 *NestObj
 	NestedPtr3 *NestObj
 	MapOfMaps  map[string]map[string]NestObj
+	Quantity   resource.Quantity
 }
 
 func TestDiffThenPatch(t *testing.T) {
@@ -40,12 +42,12 @@ func TestDiffThenPatch(t *testing.T) {
 		[]int64{1, 2}, [3]bool{true, false, true},
 		map[string]int64{"a": 1, "b": 2, "d": 4},
 		NestObj{3, "Hello"}, &nest1, nil, &nest2,
-		map[string]map[string]NestObj{"a": {"b": nest1}, "c": {"d": nest2}}}
+		map[string]map[string]NestObj{"a": {"b": nest1}, "c": {"d": nest2}}, resource.MustParse("500Mi")}
 	o2 := Obj{2, &five, 3.14, "Bar", true,
 		[]int64{3, 4, 5}, [3]bool{true, true, false},
 		map[string]int64{"a": 2, "c": 3, "d": 4},
 		NestObj{7, "World"}, &nest2, &nest1, nil,
-		map[string]map[string]NestObj{"a": {"b": nest3}, "c": {"d": nest2}}}
+		map[string]map[string]NestObj{"a": {"b": nest3}, "c": {"d": nest2}}, resource.MustParse("1.5Gi")}
 
 	diff, err := Diff(o1, o2)
 	if err != nil {
@@ -81,12 +83,12 @@ func TestDiffPointersThenPatch(t *testing.T) {
 		[]int64{1, 2}, [3]bool{true, false, true},
 		map[string]int64{"a": 1, "b": 2, "d": 4},
 		NestObj{3, "Hello"}, &nest1, nil, &nest2,
-		map[string]map[string]NestObj{"a": {"b": nest1}, "c": {"d": nest2}}}
+		map[string]map[string]NestObj{"a": {"b": nest1}, "c": {"d": nest2}}, resource.MustParse("1.5Gi")}
 	o2 := Obj{2, &five, 3.14, "Bar", true,
 		[]int64{3, 4, 5}, [3]bool{true, true, false},
 		map[string]int64{"a": 2, "c": 3, "d": 4},
 		NestObj{7, "World"}, &nest2, &nest1, nil,
-		map[string]map[string]NestObj{"a": {"b": nest3}, "c": {"d": nest2}}}
+		map[string]map[string]NestObj{"a": {"b": nest3}, "c": {"d": nest2}}, resource.MustParse("500Mi")}
 
 	diff, err := Diff(&o1, &o2)
 	if err != nil {

--- a/pkg/obj_diff/diff_test.go
+++ b/pkg/obj_diff/diff_test.go
@@ -7,6 +7,7 @@ package obj_diff
 import (
 	"fmt"
 	. "github.com/walmartlabs/object-diff/pkg/obj_diff/helpers"
+	"k8s.io/apimachinery/pkg/api/resource"
 	"reflect"
 	"testing"
 )
@@ -21,6 +22,8 @@ type diffTestObject struct {
 func TestDiff(t *testing.T) {
 	int1 := int32(123)
 	int2 := int32(456)
+	quantity1 := resource.MustParse("500Mi")
+	quantity2 := resource.MustParse("1.5Gi")
 	i := []diffTestObject{
 		buildSimpleTest("Basic -- Int", int(-123), int(123), []PathElement{}, int(-123), int(123)),
 		buildSimpleTest("Basic -- Uint", uint(123), uint(456), []PathElement{}, uint(123), uint(456)),
@@ -34,6 +37,9 @@ func TestDiff(t *testing.T) {
 		buildSimpleTest("Object -- Array", [1]int32{int1}, [1]int32{int2}, []PathElement{NewIndexElem(0)}, int1, int2),
 		buildSimpleTest("Object -- Slice", []int32{int1}, []int32{int2}, []PathElement{NewIndexElem(0)}, int1, int2),
 		buildSimpleTest("Object -- Ptr", &int1, &int2, []PathElement{NewPtrElem()}, int1, int2),
+
+		buildSimpleTest("Object -- resource.Quantity 1", &quantity1, &quantity2, []PathElement{NewPtrElem()}, quantity1, quantity2),
+		buildSimpleTest("Object -- resource.Quantity 2", &quantity2, &quantity1, []PathElement{NewPtrElem()}, quantity2, quantity1),
 	}
 
 	tests := i


### PR DESCRIPTION
Types such as resource.Quantity have internal fields which can not be "Interfaced", this patch treats objects such as this as opaque types and replaces them directly.